### PR TITLE
Add smart output samples

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,16 @@
+Smart output samples
+
+The smartctl command needs root privileges to get all the
+information.
+
+Megaraid Controller
+smartctl -i --attributes --log=selftest /dev/sda
+
+Megaraid disk
+smartctl -i --attributes --log=selftest /dev/sda -d megaraid,0
+
+nvme
+smartctl -i --attributes --log=selftest /dev/nvme0
+
+SAS
+smartctl -i --attributes --log=selftest /dev/sda

--- a/samples/megaraid-controller.txt
+++ b/samples/megaraid-controller.txt
@@ -1,0 +1,17 @@
+smartctl 6.5 2016-05-07 r4318 [x86_64-linux-3.10.0-957.21.3.el7.x86_64] (local build)
+Copyright (C) 2002-16, Bruce Allen, Christian Franke, www.smartmontools.org
+
+=== START OF INFORMATION SECTION ===
+Vendor:               DELL
+Product:              PERC H710
+Revision:             3.13
+User Capacity:        214,748,364,800 bytes [214 GB]
+Logical block size:   512 bytes
+Logical Unit id:      0x6b083fe0d2d0f2001f56bac605829393
+Serial number:        xxx
+Device type:          disk
+Local Time is:        Wed Jul 10 04:16:26 2019 EDT
+SMART support is:     Unavailable - device lacks SMART capability.
+
+=== START OF READ SMART DATA SECTION ===
+Device does not support Self Test logging

--- a/samples/megaraid-disk.txt
+++ b/samples/megaraid-disk.txt
@@ -1,0 +1,52 @@
+smartctl 6.5 2016-05-07 r4318 [x86_64-linux-3.10.0-957.21.3.el7.x86_64] (local build)
+Copyright (C) 2002-16, Bruce Allen, Christian Franke, www.smartmontools.org
+
+=== START OF INFORMATION SECTION ===
+Vendor:               SEAGATE
+Product:              ST600MM0006
+Revision:             LS0A
+Compliance:           SPC-4
+User Capacity:        600,127,266,816 bytes [600 GB]
+Logical block size:   512 bytes
+LU is fully provisioned
+Rotation Rate:        10000 rpm
+Form Factor:          2.5 inches
+Logical Unit id:      0x5000c5007764ff6f
+Serial number:        xxx
+Device type:          disk
+Transport protocol:   SAS (SPL-3)
+Local Time is:        Wed Jul 10 04:16:47 2019 EDT
+SMART support is:     Available - device has SMART capability.
+SMART support is:     Enabled
+Temperature Warning:  Disabled or Not Supported
+
+=== START OF READ SMART DATA SECTION ===
+Current Drive Temperature:     33 C
+Drive Trip Temperature:        50 C
+
+Manufactured in week 33 of year 2014
+Specified cycle count over device lifetime:  10000
+Accumulated start-stop cycles:  310
+Specified load-unload count over device lifetime:  300000
+Accumulated load-unload cycles:  13218
+Elements in grown defect list: 0
+
+Vendor (Seagate) cache information
+  Blocks sent to initiator = 3556778918
+  Blocks received from initiator = 721163403
+  Blocks read from cache and sent to initiator = 16539604
+  Number of read and write commands whose size <= segment size = 32074580
+  Number of read and write commands whose size > segment size = 227
+
+Vendor (Seagate/Hitachi) factory information
+  number of hours powered up = 14340.72
+  number of minutes until next internal SMART test = 31
+
+SMART Self-test log
+Num  Test              Status                 segment  LifeTime  LBA_first_err [SK ASC ASQ]
+     Description                              number   (hours)
+# 1  Background short  Completed                  64       2                 - [-   -    -]
+# 2  Reserved(7)       Completed                  48       2                 - [-   -    -]
+# 3  Background short  Completed                  64       1                 - [-   -    -]
+
+Long (extended) Self Test duration: 3777 seconds [63.0 minutes]

--- a/samples/nvme.txt
+++ b/samples/nvme.txt
@@ -1,0 +1,37 @@
+smartctl 6.5 2016-05-07 r4318 [x86_64-linux-3.10.0-957.21.3.el7.x86_64] (local build)
+Copyright (C) 2002-16, Bruce Allen, Christian Franke, www.smartmontools.org
+
+=== START OF INFORMATION SECTION ===
+Model Number:                       Dell Express Flash NVMe P4600 1.6TB SFF
+Serial Number:                      xxx
+Firmware Version:                   QDV1DP15
+PCI Vendor ID:                      0x8086
+PCI Vendor Subsystem ID:            0x1028
+IEEE OUI Identifier:                0x5cd2e4
+Total NVM Capacity:                 1,600,321,314,816 [1.60 TB]
+Unallocated NVM Capacity:           0
+Controller ID:                      0
+Number of Namespaces:               1
+Namespace 1 Size/Capacity:          1,600,321,314,816 [1.60 TB]
+Namespace 1 Formatted LBA Size:     512
+Local Time is:                      Wed Jul 10 10:18:31 2019 CEST
+
+=== START OF SMART DATA SECTION ===
+SMART/Health Information (NVMe Log 0x02, NSID 0xffffffff)
+Critical Warning:                   0x00
+Temperature:                        27 Celsius
+Available Spare:                    100%
+Available Spare Threshold:          10%
+Percentage Used:                    0%
+Data Units Read:                    7,896,710 [4.04 TB]
+Data Units Written:                 2,063,400 [1.05 TB]
+Host Read Commands:                 58,764,536
+Host Write Commands:                15,612,248
+Controller Busy Time:               8
+Power Cycles:                       193
+Power On Hours:                     2,467
+Unsafe Shutdowns:                   132
+Media and Data Integrity Errors:    0
+Error Information Log Entries:      0
+Warning  Comp. Temperature Time:    0
+Critical Comp. Temperature Time:    0

--- a/samples/sas.txt
+++ b/samples/sas.txt
@@ -1,0 +1,40 @@
+smartctl 6.5 2016-05-07 r4318 [x86_64-linux-3.10.0-957.21.3.el7.x86_64] (local build)
+Copyright (C) 2002-16, Bruce Allen, Christian Franke, www.smartmontools.org
+
+=== START OF INFORMATION SECTION ===
+Vendor:               TOSHIBA
+Product:              AL15SEB120NY
+Revision:             EF03
+Compliance:           SPC-4
+User Capacity:        1,200,243,695,616 bytes [1.20 TB]
+Logical block size:   512 bytes
+Formatted with type 2 protection
+Rotation Rate:        10000 rpm
+Form Factor:          2.5 inches
+Logical Unit id:      0x500003992893efa1
+Serial number:        xxx
+Device type:          disk
+Transport protocol:   SAS (SPL-3)
+Local Time is:        Wed Jul 10 10:18:59 2019 CEST
+SMART support is:     Available - device has SMART capability.
+SMART support is:     Enabled
+Temperature Warning:  Disabled or Not Supported
+
+=== START OF READ SMART DATA SECTION ===
+Current Drive Temperature:     23 C
+Drive Trip Temperature:        65 C
+
+Manufactured in week 05 of year 2019
+Specified cycle count over device lifetime:  50000
+Accumulated start-stop cycles:  210
+Specified load-unload count over device lifetime:  600000
+Accumulated load-unload cycles:  1458
+Elements in grown defect list: 0
+
+SMART Self-test log
+Num  Test              Status                 segment  LifeTime  LBA_first_err [SK ASC ASQ]
+     Description                              number   (hours)
+# 1  Reserved(7)       Completed                  64       4                 - [-   -    -]
+# 2  Background short  Completed                   -       3                 - [-   -    -]
+
+Long (extended) Self Test duration: 6429 seconds [107.2 minutes]


### PR DESCRIPTION
Adding samples taken running smartctl command on real baremetal
servers.

Serial numbers have been omitted on purpose.

This patch adds samples for:
Megaraid Controller
Megaraid Disk
NVME
SAS