### PR TITLE
add travis-ci configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: go
+
+sudo: false
+
+services:
+  - docker
+
+go:
+  - "1.11.5"
+
+before_install:
+  - go get golang.org/x/lint/golint
+
+env:
+  - TARGET=lint
+  - TARGET=docker
+
+script: make $TARGET

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: help
+help:
+	@echo "Targets:"
+	@echo "  docker       -- try to build the docker container"
+	@echo "  lint         -- run the linter"
+
+.PHONY: docker
+docker:
+	docker build . -f Dockerfile
+
+.PHONY: lint
+lint:
+	golint -set_exit_status smart_exporter.go
+	go vet smart_exporter.go


### PR DESCRIPTION
Configure travis jobs to run the go linter and docker builds, using a
Makefile to make it easier for developers to run the same tests locally.